### PR TITLE
feature(manage properties): add a manage properties page

### DIFF
--- a/UI/css/manage_properties.css
+++ b/UI/css/manage_properties.css
@@ -1,0 +1,27 @@
+.main-header__heading{
+    font-style: 24px;
+    text-align: center;
+    margin: 1.5rem;
+    color: #045e32;
+  }
+
+.manage_properties .title{
+    display: flex;
+    justify-content: center;   
+}
+
+.manage_properties .title{
+    font-size: 28px;
+    padding-bottom: 0.63rem;
+}
+
+.manage_properties hr{
+    border: 2px solid #7DBA21;
+    width: 120px;
+    border-radius: 3px;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 2rem;
+}
+
+

--- a/UI/manage_properties.html
+++ b/UI/manage_properties.html
@@ -1,0 +1,67 @@
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <link rel="stylesheet" href="css/view_all properties.css">
+    <link rel="stylesheet" href="css/index.css">
+    <link rel="stylesheet" href="css/manage_properties.css">
+    <link rel="stylesheet" href="css/dashboard.css">
+    <title> Manage Properties</title>
+</head>
+<body>
+    <div class="profile_container">
+        <div class="grid-container">
+            <header class="header">
+                <div class="header__search"><a href="index.html" class="logo"><img src="img/icons/Logoproperty_lite.svg" alt="property pro-lite logo"></a></div>
+                <div class="search_box">
+                        <select name="type" id="">
+                            <option value="type">type</option>
+                            <option value="apartment">apartment</option>
+                            <option value="land">land</option>
+                            <option value="office">office space</option>
+                        </select>
+                        <select name="status" id="status">
+                            <option value="all">all</option>
+                            <option value="rent">for rent</option>
+                            <option value="land">for sold</option>
+                        </select>
+                        <button id="search"><img src="img/icons/Vectorsearch.svg" alt="search button">Find</button>
+                    </div>
+                <div class="header__avatar">Welcome, Oyin</div>
+            </header>
+            <aside class="sidenav">
+                <ul class="sidenav__list">
+                    <li class="sidenav__list-item"><img src="img/icons/Grouppost property.png" alt="post a proprty icon" class="sidenavbar-icon">Dashboard</li>
+                    <li class="sidenav__list-item"><img src="img/icons/Grouppost property.png" alt="post a proprty icon" class="sidenavbar-icon">Post a property</li>
+                    <li class="sidenav__list-item"><img src="img/icons/Groupmanage_property.png" alt="manage proprties icon" class="sidenavbar-icon">Manage properties</li>
+                    <li class="sidenav__list-item"><a href="#my_profile"><img src="img/icons/Groupprofile.png" alt="my profile icon" class="sidenavbar-icon">My Profile</a></li>
+                    <li class="sidenav__list-item"><a href="#change_password"><img src="img/icons/changepassword.png" alt="change password icon" class="sidenavbar-icon">Change Password</a></li>
+                    <li class="sidenav__list-item"><a><img src="img/icons/Grouplogout.png" alt=" log out icon" class="sidenavbar-icon">Log out</a></li>
+                </ul>
+            </aside>
+            <main class="main">
+                <div class="main-header__heading"></div>
+                <div class="property_container">   
+                        <div class="property">
+                            <a href="#"><img src="img/houses/evan-dvorkin-1463592-unsplash.jpg" alt="">
+                            <div class="tag">For Sale</div>
+                                <h3>Modern Family Home</h3>
+                                <p>Ibeju,Lekki</p>
+                            </a>
+                        </div>
+                        <div class="property">
+                                <a href="#"><img src="img/houses/evan-dvorkin-1463592-unsplash.jpg" alt="">
+                                    <h3>Modern Family Home</h3>
+                                    <p>Ibeju,Lekki</p>
+                                </a>
+                        </div>
+                        <div class="property">
+                                <a href="#"><img src="img/houses/evan-dvorkin-1463592-unsplash.jpg" alt="">
+                                    <h3>Modern Family Home</h3>
+                                    <p>Ibeju,Lekki</p>
+                                </a>
+                        </div>
+       </main>
+</body>
+</html>


### PR DESCRIPTION

#### What does this PR do?
Add a Manage Properties page where a user can view all properties he has posted on the PropertyPro-Lite App.

#### Description of Task to be completed?
Carry out the following Tasks 
- Rewrite the path to view-property page on index.hml
- Create a manage-properties page

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-UI-manage_properties-166672647 branch and launch manage_properties.html

#### What are the relevant pivotal tracker stories?
#166672647

#### Screenshot
![image](https://user-images.githubusercontent.com/46001371/60555771-3dac2f00-9d36-11e9-87c3-f0c981a7d019.png)


[Finishes )]