### PR TITLE
#167107153 Add Signup Endpoint

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 PORT=4000
+SIGN_SECRET=shhhh

--- a/API/src/app.js
+++ b/API/src/app.js
@@ -1,11 +1,21 @@
 import express from "express";
 import dotenv from "dotenv";
+import bodyparser from "body-parser";
+import authRoutes from "./routes/authRoutes";
 
 dotenv.config();
 
 // Create express app
 const app = express();
 
+// parse application/x-www-form-urlencoded
+app.use(bodyparser.urlencoded({ extended: false }));
+
+// parse application/json
+app.use(bodyparser.json());
+
+// Routes
+app.use("/api/v1/auth", authRoutes);
 // Default route
 app.get("/api/v1", (req, res) => {
   res.status(200).json({

--- a/API/src/controllers/auth.js
+++ b/API/src/controllers/auth.js
@@ -1,0 +1,49 @@
+import bcrypt from "bcrypt";
+import users from "../data/users";
+import Helpers from "../helpers/helpers";
+
+class UserController {
+  /* eslint camelcase: 0 */
+  static async createAccount(req, res) {
+    try {
+      const { first_name, last_name, email, phoneNumber, address, password } = req.body;
+      let id = 0;
+      if (users.length === 0) {
+        id = 1;
+      } else {
+        const lastIndex = users.length - 1;
+        id = users[lastIndex].id + 1;
+      }
+      const passwordHash = await bcrypt.hash(password, 8);
+      const user = {
+        id,
+        first_name,
+        last_name,
+        email,
+        phoneNumber,
+        address,
+        password: passwordHash,
+        is_admin: false
+      };
+      users.push(user);
+      const token = Helpers.generateToken(id, false);
+      return res.status(201).json({
+        status: "Success",
+        data: {
+          token,
+          id,
+          first_name,
+          last_name,
+          email
+        }
+      });
+    } catch (e) {
+      return res.status(500).json({
+        status: "500 Server Error",
+        error: "Something went wrong, Please try again soon"
+      });
+    }
+  }
+}
+
+export default UserController;

--- a/API/src/data/users.js
+++ b/API/src/data/users.js
@@ -1,0 +1,26 @@
+import bcrypt from "bcrypt";
+
+const users = [
+  {
+    id: 1,
+    first_name: "oyinkansola",
+    last_name: "alabi",
+    email: "alabi.oyinkansola14@outlook.com",
+    phoneNumber: "07033282723",
+    address: "3, Skrest Road, Lagos, Nigeria",
+    password: bcrypt.hashSync("halabee", 8),
+    is_admin: false
+  },
+  {
+    id: 2,
+    first_name: "jessica",
+    last_name: "alabi",
+    email: "alabi.oyinkansola@outlook.com",
+    phoneNumber: "07033282563",
+    address: "3, Skrest Street, Lagos, Nigeria",
+    password: bcrypt.hashSync("alahbee", 8),
+    is_admin: false
+  }
+];
+
+export default users;

--- a/API/src/helpers/helpers.js
+++ b/API/src/helpers/helpers.js
@@ -1,0 +1,15 @@
+import jwt from "jsonwebtoken";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+class Helpers {
+  static generateToken(userid, isAdmin) {
+    const token = jwt.sign({ userid, isAdmin }, process.env.SIGN_SECRET, {
+      expiresIn: "24h"
+    });
+    return token;
+  }
+}
+
+export default Helpers;

--- a/API/src/routes/authRoutes.js
+++ b/API/src/routes/authRoutes.js
@@ -1,0 +1,8 @@
+import express from "express";
+import UserController from "../controllers/auth";
+
+const router = express.Router();
+
+router.post("/signup", UserController.createAccount);
+
+export default router;

--- a/API/src/test/auth.test.js
+++ b/API/src/test/auth.test.js
@@ -10,15 +10,16 @@ describe("Auth Route Endpoints", () => {
     it("should signup a user successfully provided all the required data is provided", done => {
       request(app)
         .post("/api/v1/auth/signup")
+        .set("Accept", "application/json")
         .send({
           first_name: "oyin",
           last_name: "splash",
           email: "splash@yahoo.co.uk",
           phoneNumber: "07033444447",
+          address: "23, Skye road, Lagos, Nigeria",
           password: "abc123",
           confirm_password: "abc123"
-        })
-        .set("Accept", "application/json")
+        }) 
         .expect("Content-Type", /json/)
         .expect(201)
         .expect(res => {
@@ -41,6 +42,7 @@ describe("Auth Route Endpoints", () => {
           last_name: faker.name.lastName(),
           email: "splash@yahoo",
           phoneNumber: "07033fg4447",
+          address: `${faker.address.streetAddress()}, Lagos, Nigeria`,
           password: faker.internet.password(),
           confirm_password: faker.internet.password()
         })
@@ -53,14 +55,15 @@ describe("Auth Route Endpoints", () => {
         })
         .end(done);
     });
-    it("should not signup a user if a required field contains invalid data", done => {
+    it("should not signup a user if not all required fields contain data", done => {
       request(app)
         .post("/api/v1/auth/signup")
         .send({
           first_name: faker.name.firstName(),
           last_name: faker.name.lastName(),
-          email: "splash@yahoo",
-          phoneNumber: "07033fg4447",
+          email: "",
+          phoneNumber: "",
+          address: "",
           password: faker.internet.password(),
           confirm_password: faker.internet.password()
         })
@@ -81,6 +84,7 @@ describe("Auth Route Endpoints", () => {
           last_name: faker.name.lastName(),
           email: "splash@yahoo",
           phoneNumber: "07033444447",
+          address: `${faker.address.streetAddress()}, Lagos, Nigeria`,
           password: "abc123",
           confirm_password: "abc123"
         })
@@ -140,8 +144,8 @@ describe("Auth Route Endpoints", () => {
         request(app)
           .post("/api/v1/auth/signin")
           .send({
-            email: '',
-            password: ''
+            email: "",
+            password: ""
           })
           .set("Accept", "application/json")
           .expect("Content-Type", /json/)
@@ -151,7 +155,7 @@ describe("Auth Route Endpoints", () => {
             expect(res.body.data).to.have.all.keys("status", "error");
           })
           .end(done);
-      });      
+      });
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1224,6 +1224,11 @@
         "node-releases": "^1.1.23"
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -1683,6 +1688,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
       "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg=="
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -3571,6 +3584,49 @@
         }
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -3631,6 +3687,41 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "log-symbols": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "body-parser": "^1.19.0",
     "dotenv": "^8.0.0",
     "express": "^4.17.1",
-    "faker": "^4.1.0"
+    "faker": "^4.1.0",
+    "jsonwebtoken": "^8.5.1"
   },
   "bugs": {
     "url": "https://github.com/Oyinsplash/PropertyPro-Lite/issues"


### PR DESCRIPTION
#### What does this PR do?
Add the signup API endpoint to allow users to  register an account successfully on the App.

#### Description of Task to be completed?
Carry out the following Tasks 
- Create the `/api/v1/auth/signup`  endpoint

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-API-signup_endpoint-#167107153 branch and run `npm install`
- After the dependencies have been installed, run `npm run start-dev` to start the App
- Then make a post request to the URI `http://localhost:{{port}}/api/v1/auth/signup` to test the signup endpoint.

#### What are the relevant pivotal tracker stories?
#167107153

### Screenshot
![image](https://user-images.githubusercontent.com/46001371/60729661-2a1de580-9f3b-11e9-93bc-52e9b7fe9446.png)
![image](https://user-images.githubusercontent.com/46001371/60732043-f04fdd80-9f40-11e9-92d7-15182c914a45.png)



