### PR TITLE
#167106908 Add Signup Validation

### DIFF
--- a/API/src/controllers/auth.js
+++ b/API/src/controllers/auth.js
@@ -6,7 +6,23 @@ class UserController {
   /* eslint camelcase: 0 */
   static async createAccount(req, res) {
     try {
-      const { first_name, last_name, email, phoneNumber, address, password } = req.body;
+      const {
+        first_name,
+        last_name,
+        email,
+        phoneNumber,
+        address,
+        password
+      } = req.body;
+
+      const isUserExist = users.find(
+        ({ email: currentEmail }) => email === currentEmail
+      );
+      if (isUserExist)
+        return res.status(409).json({
+          status: "409 Conflict",
+          error: "Email has been taken"
+        });
       let id = 0;
       if (users.length === 0) {
         id = 1;

--- a/API/src/middleware/validate.js
+++ b/API/src/middleware/validate.js
@@ -1,0 +1,75 @@
+import { check, validationResult } from "express-validator";
+
+export default class Validator {
+  static validateSignUp() {
+    return [
+      check(["first_name", "last_name"])
+        .exists()
+        .withMessage("This is a required field")
+        .not()
+        .isEmpty()
+        .withMessage("This field can not be left empty")
+        .isAlpha()
+        .withMessage("This field takes only alphabets")
+        .isLength({ min: 2 })
+        .withMessage("Name should be at least 2 letters long")
+        .trim()
+        .escape(),
+      check("email")
+        .exists()
+        .withMessage("This is a required field")
+        .not()
+        .isEmpty()
+        .withMessage("This field can not be left empty")
+        .isEmail()
+        .withMessage("Please enter a valid email address"),
+      check("phoneNumber")
+        .exists()
+        .withMessage("This is a required field")
+        .not()
+        .isEmpty()
+        .withMessage("This field can not be left empty")
+        .isNumeric()
+        .withMessage("Please enter a valid phone number")
+        .isLength({ min: 9, max: 11 })
+        .withMessage("Phone number should be between 9-11 characters"),
+      check("address")
+        .exists()
+        .withMessage("This is a required field")
+        .not()
+        .isEmpty()
+        .withMessage("This field can not be left empty")
+        .isLength({ min: 3 })
+        .withMessage("Address should be at least 3 letters long")
+        .trim()
+        .escape(),
+      check("password")
+        .exists()
+        .withMessage("This is a required field")
+        .not()
+        .isEmpty()
+        .withMessage("This field can not be left empty")
+        .isLength({ min: 5 })
+        .withMessage("Password should be at least 6 letters long")
+        .trim()
+        .escape(),
+      check("confirm_password")
+        .exists()
+        .withMessage("This is a required field")
+        .not()
+        .isEmpty()
+    ];
+  }
+
+  static async myValidationResult(req, res, next) {
+    const errors = validationResult(req);
+    console.log(errors.array());
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        status: "400 Invalid Request",
+        error: "Your request contains invalid parameters"
+      });
+    }
+    return next();
+  }
+}

--- a/API/src/routes/authRoutes.js
+++ b/API/src/routes/authRoutes.js
@@ -1,8 +1,14 @@
 import express from "express";
 import UserController from "../controllers/auth";
+import Validator from "../middleware/validate";
 
 const router = express.Router();
 
-router.post("/signup", UserController.createAccount);
+router.post(
+  "/signup",
+  Validator.validateSignUp(),
+  Validator.myValidationResult,
+  UserController.createAccount
+);
 
 export default router;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2135,6 +2135,15 @@
         "vary": "~1.1.2"
       }
     },
+    "express-validator": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.1.1.tgz",
+      "integrity": "sha512-AF6YOhdDiCU7tUOO/OHp2W++I3qpYX7EInMmEEcRGOjs+qoubwgc5s6Wo3OQgxwsWRGCxXlrF73SIDEmY4y3wg==",
+      "requires": {
+        "lodash": "^4.17.11",
+        "validator": "^11.0.0"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3685,8 +3694,7 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -5664,6 +5672,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz",
+      "integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "body-parser": "^1.19.0",
     "dotenv": "^8.0.0",
     "express": "^4.17.1",
+    "express-validator": "^6.1.1",
     "faker": "^4.1.0",
     "jsonwebtoken": "^8.5.1"
   },


### PR DESCRIPTION
#### What does this PR do?
Add  validation for signup to ensure users to register on the application with valid credentials

#### Description of Task to be completed?
Carry out the following Tasks 
- Add validation `/api/v1/auth/signup`  

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the (ft-API-signup_validation-167106908) branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Once the app prints a log describing that it has started running on some port, startup postman for testing
- Make a post request to the URI `http://localhost:{{port}}/api/v1/auth/signup` to test the signup endpoint, where {{port}} is the number printed to the console in the description while the app was starting
- Post the data fields described in the entity specification for a User in the requirement

#### What are the relevant pivotal tracker stories?
#167106908

#### Screenshot
![image](https://user-images.githubusercontent.com/46001371/60748936-ece14400-9f8a-11e9-84fe-6813b5a3b205.png)
