### PR TITLE
#167099371 Add Signin API Validation

### DIFF
--- a/API/src/controllers/auth.js
+++ b/API/src/controllers/auth.js
@@ -1,4 +1,5 @@
 import bcrypt from "bcrypt";
+// import { read } from "fs";
 import users from "../data/users";
 import Helpers from "../helpers/helpers";
 
@@ -15,10 +16,10 @@ class UserController {
         password
       } = req.body;
 
-      const isUserExist = users.find(
+      const userExist = users.find(
         ({ email: currentEmail }) => email === currentEmail
       );
-      if (isUserExist)
+      if (userExist)
         return res.status(409).json({
           status: "409 Conflict",
           error: "Email has been taken"
@@ -56,7 +57,52 @@ class UserController {
     } catch (e) {
       return res.status(500).json({
         status: "500 Server Error",
-        error: "Something went wrong, Please try again soon"
+        error: "Something went wrong, Please try again soon."
+      });
+    }
+  }
+
+  //  Signin
+  static async loginAccount(req, res) {
+    try {
+      const { email, password } = req.body;
+
+      const userExist = users.find(
+        ({ email: currentEmail }) => email === currentEmail
+      );
+      if (!userExist) {
+        return res.status(401).json({
+          status: "401 Unauthorized",
+          error: "Access is denied due to invalid credentials."
+        });
+      }
+      const validPassword = await bcrypt.compare(password, userExist.password);
+      if (!validPassword) {
+        return res.status(401).json({
+          status: "401 Unauthorized",
+          error: "Access is denied due to invalid credentials."
+        });
+      }
+      const { id, first_name, last_name, isAdmin } = userExist;
+      const token = Helpers.generateToken({
+        id,
+        isAdmin
+      });
+      return res.status(200).json({
+        status: "Success",
+        data: {
+          token,
+          id,
+          first_name,
+          last_name,
+          email
+        }
+      });
+    } catch (e) {
+      return res.status(500).json({
+        status: "500 Internal Server Error",
+        error:
+          "The server encountered an internal error or misconfiguration and was unable to complete your request."
       });
     }
   }

--- a/API/src/middleware/validate.js
+++ b/API/src/middleware/validate.js
@@ -61,9 +61,32 @@ export default class Validator {
     ];
   }
 
+  static validateSignIn() {
+    return [
+      check("email")
+        .exists()
+        .withMessage("This is a required field")
+        .not()
+        .isEmpty()
+        .withMessage("This field can not be left empty")
+        .normalizeEmail()
+        .isEmail()
+        .withMessage("Please enter a valid email address and password"),
+      check("password")
+        .exists()
+        .withMessage("This is a required field")
+        .not()
+        .isEmpty()
+        .withMessage("This field can not be left empty")
+        .isLength({ min: 5 })
+        .withMessage("Password should be at least 6 letters long")
+        .trim()
+        .escape()
+    ];
+  }
+
   static async myValidationResult(req, res, next) {
     const errors = validationResult(req);
-    console.log(errors.array());
     if (!errors.isEmpty()) {
       return res.status(400).json({
         status: "400 Invalid Request",

--- a/API/src/routes/authRoutes.js
+++ b/API/src/routes/authRoutes.js
@@ -11,4 +11,11 @@ router.post(
   UserController.createAccount
 );
 
+router.post(
+  "/signin",
+  Validator.validateSignIn(),
+  Validator.myValidationResult,
+  UserController.loginAccount
+);
+
 export default router;

--- a/API/src/test/auth.test.js
+++ b/API/src/test/auth.test.js
@@ -19,7 +19,7 @@ describe("Auth Route Endpoints", () => {
           address: "23, Skye road, Lagos, Nigeria",
           password: "abc123",
           confirm_password: "abc123"
-        }) 
+        })
         .expect("Content-Type", /json/)
         .expect(201)
         .expect(res => {


### PR DESCRIPTION
#### What does this PR do?
Add the API signin validation

#### Description of Task to be completed?
Carry out the following Tasks 
- Create User Model, User services, Auth controller and a signup route to manage User signup activities 
- Add `/api/v1/auth/signin`  endpoint

#### How should this be manually tested?
- Clone repo and change into the working directory
- Switch to the ft-API-signin_validation-#167099371 branch and run `npm install`
- Once all the dependencies are installed, run `npm run dev` to start the App
- Once the app prints a log describing that it has started running on some port, startup postman for testing
- Make a post request to the URI `http://localhost:{{port}}/api/v1/auth/signin` to test the signin endpoint, where {{port}} is the number printed to the console in the description while the app was starting
- Post the data fields described in the entity specification for a User in the requirement

#### What are the relevant pivotal tracker stories?
#167099371

#### Screenshot
![image](https://user-images.githubusercontent.com/46001371/61007966-2983b580-a366-11e9-89c0-815e657f6d48.png)
